### PR TITLE
Corrected filename usage, Add svMotion privileges

### DIFF
--- a/create_vCenter_User.ps1
+++ b/create_vCenter_User.ps1
@@ -10,8 +10,8 @@ param(
 
 clear-host
 
-$usage = "Create_Rubrik_Role.ps1 -vCenter vCenterFQDNorIP -Username RubrikServiceAccountName -Domain AuthenticationDomain"
-$example = 'Create_Rubrik_Role.ps1 -vCenter "vcenter.rubrik.local" -Username svc_rubrik -Domain Rubrik.com' 
+$usage = "create_vCenter_User.ps1 -vCenter vCenterFQDNorIP -Username RubrikServiceAccountName -Domain AuthenticationDomain"
+$example = 'create_vCenter_User.ps1 -vCenter "vcenter.rubrik.local" -Username svc_rubrik -Domain Rubrik.com' 
 
 Write-Host "PowerCLI script to create Rubrik Role which includes required privileges and assigns the Rubrik Service Account to Role" -ForeGroundColor Cyan 
 
@@ -44,6 +44,8 @@ $Rubrik_Privileges = @(
 'Host.Config.Storage'
 'Network.Assign'
 'Resource.AssignVMToPool'
+'Resource.ColdMigrate'
+'Resource.HotMigrate'
 'Sessions.TerminateSession'
 'Sessions.ValidateSession'
 'System.Anonymous'


### PR DESCRIPTION
The file name in the usage and example didn't match the actual file name so I corrected that

The set of privileges didn't include the storage vMotion privileges. This is in support of the storage vMotion from Rubrik UI feature added in 5.0.1. Without the privileges this operation will fail due to lack of authorisation of the service account.

# Description

Please describe your pull request in detail.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
